### PR TITLE
Enable Markdown rendering in gloss blocks

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin } from "obsidian";
+import { MarkdownPostProcessorContext, Plugin } from "obsidian";
 
 import { GlossParser } from "src/parser/main";
 import { GlossRenderer } from "src/render/main";
@@ -9,22 +9,26 @@ import { PluginSettingsWrapper } from "src/settings/wrapper";
 export default class LingGlossPlugin extends Plugin {
     settings = new PluginSettingsWrapper(this);
     parser = new GlossParser(this.settings);
-    renderer = new GlossRenderer(this.settings);
+    renderer = new GlossRenderer(this.settings, this);
 
     async onload() {
         await this.settings.load();
 
         this.addSettingTab(new PluginSettingsTab(this, this.settings));
 
-        this.registerMarkdownCodeBlockProcessor("gloss", (src, el, _) => this.processGlossMarkdown(src, el, false));
-        this.registerMarkdownCodeBlockProcessor("ngloss", (src, el, _) => this.processGlossMarkdown(src, el, true));
+        this.registerMarkdownCodeBlockProcessor("gloss", (src, el, ctx) => this.processGlossMarkdown(src, el, ctx, false));
+        this.registerMarkdownCodeBlockProcessor("ngloss", (src, el, ctx) => this.processGlossMarkdown(src, el, ctx, true));
     }
 
-    private processGlossMarkdown(source: string, el: HTMLElement, nlevel: boolean) {
+    private processGlossMarkdown(source: string, el: HTMLElement, ctx: MarkdownPostProcessorContext, nlevel: boolean) {
         const glossData = this.parser.parse(source, nlevel);
 
         if (glossData.success) {
-            this.renderer.renderGloss(el, glossData.data);
+            this.renderer.renderGloss(
+                el,
+                glossData.data,
+                ctx.sourcePath ?? this.app.workspace.getActiveFile()?.path ?? "",
+            );
         } else {
             this.renderer.renderErrors(el, glossData.errors);
         }

--- a/styles.css
+++ b/styles.css
@@ -45,6 +45,10 @@
     gap: 1em 1em;
 }
 
+.ling-gloss-elements p {
+    margin: 0;
+}
+
 .ling-gloss-postamble {
     display: flex;
     flex-wrap: wrap;


### PR DESCRIPTION
- render gloss text via Obsidian `MarkdownRenderer` when `\set markup` or setting is on
- extend helper to support async block content while preserving whitespace fallback
- pass plugin + `sourcePath` from the code-block processor to the renderer